### PR TITLE
feat: Incorporated Saha Sourav's feedback

### DIFF
--- a/00_tools.py
+++ b/00_tools.py
@@ -21,7 +21,9 @@ def time_operation(
     start_time = time.perf_counter()
     result = func(*args, **kwargs)
     # Force evaluation for lazy operations
-    if hasattr(result, "compute"):
+    if hasattr(result, "_evaluate"):
+        result = result._evaluate()
+    elif hasattr(result, "compute"):
         result = result.compute()
     elif hasattr(result, "values"):
         _ = result.values  # Access values to force computation

--- a/02_benchmark.py
+++ b/02_benchmark.py
@@ -123,14 +123,26 @@ def run_benchmarks() -> List[Dict[str, Any]]:
         )
     )
 
-    # Window functions
+    # groupby-dense-rank
     results.append(
         time_operation(
-            "window_functions",
+            "groupby-dense-rank",
             df_lib,
             lambda: orders.assign(
                 running_total=orders.groupby("customer_id")["total_amount"].cumsum(),
                 rank=orders.groupby("customer_id")["total_amount"].rank(method="dense"),
+            ),
+        )
+    )
+
+    # groupby-first-rank
+    results.append(
+        time_operation(
+            "groupby-first-rank",
+            df_lib,
+            lambda: orders.assign(
+                running_total=orders.groupby("customer_id")["total_amount"].cumsum(),
+                rank=orders.groupby("customer_id")["total_amount"].rank(method="first"),
             ),
         )
     )

--- a/03_polars.py
+++ b/03_polars.py
@@ -137,8 +137,8 @@ def run_benchmarks(
 
     results.append(time_operation("four_table_join", pl, four_table_join_polars))
 
-    # Window functions
-    def window_functions_polars():
+    # groupby-dense-rank
+    def groupby_dense_rank_polars():
         # Use Polars native window functions.
         # Cast rank to float to match pandas output dtype.
         result = orders.with_columns(
@@ -151,7 +151,23 @@ def run_benchmarks(
         )
         return result
 
-    results.append(time_operation("window_functions", pl, window_functions_polars))
+    results.append(time_operation("groupby-dense-rank", pl, groupby_dense_rank_polars))
+
+    # groupby-first-rank
+    def groupby_first_rank_polars():
+        # Use Polars native window functions with first ranking method.
+        # Cast rank to float to match pandas output dtype.
+        result = orders.with_columns(
+            pl.col("total_amount").cum_sum().over("customer_id").alias("running_total"),
+            pl.col("total_amount")
+            .rank(method="ordinal")
+            .over("customer_id")
+            .cast(pl.Float64)
+            .alias("rank"),
+        )
+        return result
+
+    results.append(time_operation("groupby-first-rank", pl, groupby_first_rank_polars))
 
     # String operations
     def string_operations_polars():


### PR DESCRIPTION
This changes the method to force lazy evaluation on fireducks from `.result()` to `._evaluate()` as the proper method to avoid unfair computations.

The groupby-dense-rank operation has a bug on fireducks that slows it down, but will hopefully be fixed soon. For a fairer comparison, a groupby-first-rank benchmark was also added.